### PR TITLE
Sample cross app communication

### DIFF
--- a/sandstone/apps/codeeditor/static/editor.js
+++ b/sandstone/apps/codeeditor/static/editor.js
@@ -1,7 +1,12 @@
 'use strict';
 
 angular.module('sandstone.editor', ['ui.ace','treeControl'])
-
+.run(
+    function initializeServices(EditorService) {
+        //Initializes the services
+        // Dummy Method
+    }
+)
 .config(['$stateProvider', '$urlRouterProvider' ,function($stateProvider, $urlRouterProvider){
   $stateProvider
     .state('editor', {

--- a/sandstone/apps/filebrowser/static/filebrowser.controller.js
+++ b/sandstone/apps/filebrowser/static/filebrowser.controller.js
@@ -73,6 +73,7 @@ angular.module('sandstone.filebrowser')
   };
 
   self.openFileInEditor = function() {
+      window.location.href = '#/editor';
       var message = {
           key: 'editor:openDocument',
           data: {

--- a/sandstone/client/sandstone/components/updateservice/updateservice.js
+++ b/sandstone/client/sandstone/components/updateservice/updateservice.js
@@ -11,8 +11,8 @@ angular.module('sandstone.updateservice', [])
         var websocketAddress = protocol + window.location.hostname + ':' + window.location.port + '/messages';
         ws = new WebSocket(websocketAddress);
         ws.onmessage = function(e) {
-            // TODO do something on receiving message
-            console.log(JSON.parse(e.data));
+            var data = JSON.parse(e.data);
+            $rootScope.$emit(data.key, data.data);
         };
     };
 

--- a/sandstone/client/sandstone/sandstone.mod.js
+++ b/sandstone/client/sandstone/sandstone.mod.js
@@ -7,6 +7,12 @@ function getSandstoneModule(depList) {
       var self = this;
       self.currentUrl = PageService.getCurrentUrl;
     }])
+    .run(
+        function initializeServices(EditorService) {
+            //Initializes the services
+            // Dummy Method
+        }
+    )
     .factory('PageService', ['$location',function($location) {
       return {
         getCurrentUrl: function () {

--- a/sandstone/client/sandstone/sandstone.mod.js
+++ b/sandstone/client/sandstone/sandstone.mod.js
@@ -7,12 +7,6 @@ function getSandstoneModule(depList) {
       var self = this;
       self.currentUrl = PageService.getCurrentUrl;
     }])
-    .run(
-        function initializeServices(EditorService) {
-            //Initializes the services
-            // Dummy Method
-        }
-    )
     .factory('PageService', ['$location',function($location) {
       return {
         getCurrentUrl: function () {


### PR DESCRIPTION
Open a file from the Filebrowser into the Editor
- Adds a method to inject the EditorService when application bootstraps
- Refactor openDocument method so it can be called from outside, as well as from within the private methods of the service