### PR TITLE
Filetree overhaul

### DIFF
--- a/sandstone/apps/filebrowser/posixfs.py
+++ b/sandstone/apps/filebrowser/posixfs.py
@@ -145,7 +145,8 @@ class PosixFS():
                     'owner': parts[3],
                     'group': parts[4],
                     'filepath': filepath,
-                    'filename': parts[-1]
+                    'filename': parts[-1],
+                    'dirname': os.path.dirname(filepath)
                     })
         return dir_contents
 
@@ -155,10 +156,6 @@ class PosixFS():
         for i in os.listdir(dirpath):
             filepath = os.path.join(dirpath,i)
             is_dir = os.path.isdir(filepath)
-            if is_dir:
-                filepath = filepath + '/'
-            else:
-                continue
             contents.append( ( i,filepath,is_dir ) )
         contents.sort(key=lambda tup: tup[1])
         return contents

--- a/sandstone/apps/filebrowser/settings.py
+++ b/sandstone/apps/filebrowser/settings.py
@@ -19,6 +19,6 @@ APP_SPECIFICATION = {
 }
 
 FILESYSTEM_ROOT_DIRECTORIES = (
-    os.path.join('$HOME', ''),
-    '/tmp/',
+    os.path.join('$HOME'),
+    '/tmp',
     )

--- a/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
+++ b/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
@@ -70,7 +70,12 @@ angular.module('sandstone.filetreedirective', [])
       self.removeNode = function(node) {
           var parentNode = self.getParentNode(node);
           if(parentNode) {
-              parentNode.children.splice(node, 1);
+              var nodeToBeRemoved = parentNode.children.filter(function(el) {
+                  return el.filepath === node.filepath;
+              });
+              if(nodeToBeRemoved) {
+                  parentNode.children.splice(parentNode.children.indexOf(nodeToBeRemoved[0]), 1);  
+              }
           }
       };
 

--- a/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
+++ b/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
@@ -29,6 +29,51 @@ angular.module('sandstone.filetreedirective', [])
         self.treeData.filetreeContents = data;
       };
 
+      self.getParentNode = function(node) {
+          // Depth First Search to find the parent node for a given node
+          var s = [];
+          self.treeData.filetreeContents.forEach(function(element) {
+              s.push(element);
+          });
+          var isFound = false;
+          var parentNode = null;
+
+          while(!isFound || s.length == 0) {
+              // Pop the first element of the array
+              var currentElement = s.shift();
+              // Base case
+              if(currentElement.filepath == node.dirname) {
+                  isFound = true;
+                  parentNode = currentElement;
+              } else if(currentElement.type == 'dir') {
+                  if(node.dirname.indexOf(currentElement.filepath) != -1) {
+                      // Push children of elements on stack
+                      currentElement.children.forEach(function(child) {
+                          // Prepend to stack if directory
+                          if(child.type == 'dir') {
+                              s.unshift(child);
+                          }
+                      });
+                  }
+              }
+          }
+          return parentNode;
+      };
+
+      self.addNode = function(node) {
+          var parentNode = self.getParentNode(node);
+          if(parentNode) {
+              parentNode.children.push(node);
+          }
+      };
+
+      self.removeNode = function(node) {
+          var parentNode = self.getParentNode(node);
+          if(parentNode) {
+              parentNode.splice(node, 1);
+          }
+      };
+
       self.initializeFiletree = function () {
         if(self.leafLevel == "file") {
           FilesystemService.getFiles('', self.populateTreeData);

--- a/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
+++ b/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
@@ -70,7 +70,7 @@ angular.module('sandstone.filetreedirective', [])
       self.removeNode = function(node) {
           var parentNode = self.getParentNode(node);
           if(parentNode) {
-              parentNode.splice(node, 1);
+              parentNode.children.splice(node, 1);
           }
       };
 

--- a/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
+++ b/sandstone/client/sandstone/components/filetreedirective/filetreedirective.js
@@ -64,6 +64,9 @@ angular.module('sandstone.filetreedirective', [])
           var parentNode = self.getParentNode(node);
           if(parentNode) {
               parentNode.children.push(node);
+              if(node.type == 'dir') {
+                  node.children = [];
+              }
           }
       };
 
@@ -74,7 +77,7 @@ angular.module('sandstone.filetreedirective', [])
                   return el.filepath === node.filepath;
               });
               if(nodeToBeRemoved) {
-                  parentNode.children.splice(parentNode.children.indexOf(nodeToBeRemoved[0]), 1);  
+                  parentNode.children.splice(parentNode.children.indexOf(nodeToBeRemoved[0]), 1);
               }
           }
       };
@@ -286,9 +289,14 @@ angular.module('sandstone.filetreedirective', [])
           if(self.leafLevel == "dir") {
             FilesystemService.getFolders(node, self.populatetreeContents);
           } else if(self.leafLevel == "file") {
-            FilesystemService.getFiles(node, self.populatetreeContents);
+            FilesystemService.getFiles(node, self.populateDirContents);
           }
         }
+      };
+      self.populateDirContents = function(data, status, headers, config, node) {
+          for(var i = 0; i < data.length; i++) {
+              self.addNode(data[i]);
+          }
       };
     }
   ]};

--- a/sandstone/client/sandstone/components/filetreedirective/tests/filetree.directive.test.js
+++ b/sandstone/client/sandstone/components/filetreedirective/tests/filetree.directive.test.js
@@ -9,6 +9,7 @@ describe('sandstone.filetree', function() {
     var dirs = [{
           "filepath": "/home/user/dir1",
           "filename": "dir1",
+          "dirname": '/home/user',
           "group": "saurabh",
           "is_accessible": true,
           "perm": "-rw-rw-r--",
@@ -19,6 +20,7 @@ describe('sandstone.filetree', function() {
         }, {
           "filepath": "/home/user/dir2",
           "filename": "dir2",
+          "dirname": '/home/user',
           "group": "root",
           "is_accessible": false,
           "perm": "-rw-r--r--",
@@ -30,6 +32,7 @@ describe('sandstone.filetree', function() {
         {
           "filepath": "/home/user/dir3",
           "filename": "dir3",
+          "dirname": '/home/user',
           "group": "saurabh",
           "is_accessible": true,
           "perm": "-rw-rw-r--",
@@ -41,6 +44,7 @@ describe('sandstone.filetree', function() {
         {
           "filepath": "/home/user/dir4",
           "filename": "dir4",
+          "dirname": '/home/user',
           "group": "saurabh",
           "is_accessible": true,
           "perm": "-rw-rw-r--",
@@ -54,18 +58,21 @@ describe('sandstone.filetree', function() {
           {
               'type': 'dir',
               'filename': 'user',
-              'filepath': '/home/user'
+              'filepath': '/home/user',
+              'dirname': '/home'
           },
           {
               'type': 'dir',
               'filename': 'tmp',
-              'filepath': '/tmp'
+              'filepath': '/tmp',
+              'dirname': '/tmp'
           }
       ];
 
       var files = [{
             "filepath": "/home/user/dir1",
             "filename": "dir1",
+            "dirname": '/home/user',
             "group": "saurabh",
             "is_accessible": true,
             "perm": "-rw-rw-r--",
@@ -75,6 +82,7 @@ describe('sandstone.filetree', function() {
           }, {
             "filepath": "/home/user/dir2",
             "filename": "dir2",
+            "dirname": '/home/user',
             "group": "root",
             "is_accessible": false,
             "perm": "-rw-r--r--",
@@ -85,6 +93,7 @@ describe('sandstone.filetree', function() {
           {
             "filepath": "/home/user/file1",
             "filename": "file1",
+            "dirname": '/home/user',
             "group": "root",
             "is_accessible": false,
             "perm": "-rw-r--r--",
@@ -260,6 +269,28 @@ describe('sandstone.filetree', function() {
                 dest_filepath: '/home/user/some_new_file'
             });
             expect(isolateScope.updateFiletree).toHaveBeenCalled();
+        });
+        it('addNodeToFiletree', function() {
+            isolateScope.describeSelection(isolateScope.treeData.filetreeContents[0], true);
+            isolateScope.getDirContents(isolateScope.treeData.filetreeContents[0], true);
+
+            var node_1 = {
+                'filepath': '/home/user/dir1/file1',
+                'filename': 'file1',
+                'dirname': '/home/user/dir1',
+                'type': 'file'
+            };
+            var node_2 = {
+                'filepath': '/home/user/dir1/file2',
+                'filename': 'file1',
+                'dirname': '/home/user/dir1',
+                'type': 'file'
+            };
+
+            isolateScope.addNode(node_1);
+            isolateScope.addNode(node_2);
+            expect(isolateScope.treeData.filetreeContents[0].children[0].children.length).toBe(2);
+
         });
       });
       describe('directive', function() {

--- a/sandstone/client/sandstone/components/filetreedirective/tests/filetree.directive.test.js
+++ b/sandstone/client/sandstone/components/filetreedirective/tests/filetree.directive.test.js
@@ -282,7 +282,7 @@ describe('sandstone.filetree', function() {
             };
             var node_2 = {
                 'filepath': '/home/user/dir1/file2',
-                'filename': 'file1',
+                'filename': 'file2',
                 'dirname': '/home/user/dir1',
                 'type': 'file'
             };
@@ -298,19 +298,28 @@ describe('sandstone.filetree', function() {
 
             var node_1 = {
                 'filepath': '/home/user/dir1',
-                'filename': 'dir',
+                'filename': 'dir1',
                 'dirname': '/home/user',
-                'type': 'file'
+                'type': 'dir'
             };
             var node_2 = {
                 'filepath': '/home/user/file1',
-                'filename': 'dir',
+                'filename': 'file1',
                 'dirname': '/home/user',
                 'type': 'file'
             };
+
+            var nonexistentNode = {
+                'filepath': '/home/user/file12',
+                'filename': 'file12',
+                'dirname': '/home/user',
+                'type': 'file'
+            }
+
             isolateScope.removeNode(node_1);
             isolateScope.removeNode(node_2)
-            expect(isolateScope.treeData.filetreeContents[0].children.length).toBe(1);
+            isolateScope.removeNode(nonexistentNode);
+            expect(isolateScope.treeData.filetreeContents[0].children.length).toBe(0);
         });
       });
       describe('directive', function() {

--- a/sandstone/client/sandstone/components/filetreedirective/tests/filetree.directive.test.js
+++ b/sandstone/client/sandstone/components/filetreedirective/tests/filetree.directive.test.js
@@ -270,7 +270,7 @@ describe('sandstone.filetree', function() {
             });
             expect(isolateScope.updateFiletree).toHaveBeenCalled();
         });
-        it('addNodeToFiletree', function() {
+        it('addNode', function() {
             isolateScope.describeSelection(isolateScope.treeData.filetreeContents[0], true);
             isolateScope.getDirContents(isolateScope.treeData.filetreeContents[0], true);
 
@@ -291,6 +291,26 @@ describe('sandstone.filetree', function() {
             isolateScope.addNode(node_2);
             expect(isolateScope.treeData.filetreeContents[0].children[0].children.length).toBe(2);
 
+        });
+        it('removeNode', function() {
+            isolateScope.describeSelection(isolateScope.treeData.filetreeContents[0], true);
+            isolateScope.getDirContents(isolateScope.treeData.filetreeContents[0], true);
+
+            var node_1 = {
+                'filepath': '/home/user/dir1',
+                'filename': 'dir',
+                'dirname': '/home/user',
+                'type': 'file'
+            };
+            var node_2 = {
+                'filepath': '/home/user/file1',
+                'filename': 'dir',
+                'dirname': '/home/user',
+                'type': 'file'
+            };
+            isolateScope.removeNode(node_1);
+            isolateScope.removeNode(node_2)
+            expect(isolateScope.treeData.filetreeContents[0].children.length).toBe(1);
         });
       });
       describe('directive', function() {

--- a/sandstone/lib/filewatcher.py
+++ b/sandstone/lib/filewatcher.py
@@ -2,6 +2,7 @@ from watchdog.observers import Observer
 from sandstone.lib.broadcast.manager import BroadcastManager
 from sandstone.lib.broadcast.message import BroadcastMessage
 import watchdog
+import os
 
 class FilesystemEventHandler(watchdog.events.FileSystemEventHandler):
     """
@@ -13,8 +14,13 @@ class FilesystemEventHandler(watchdog.events.FileSystemEventHandler):
         Event Handler when a file is created
         """
         key = 'filetree:created_file'
+        if os.path.isdir(event.src_path):
+            file_type = 'dir'
+        else:
+            file_type = 'file'
         data = {
-            'filepath': event.src_path
+            'filepath': event.src_path,
+            'type': file_type
         }
         bmsg = BroadcastMessage(key=key, data=data)
         BroadcastManager.broadcast(bmsg)
@@ -24,8 +30,13 @@ class FilesystemEventHandler(watchdog.events.FileSystemEventHandler):
         Event Handler when a file is deleted
         """
         key = 'filetree:deleted_file'
+        if os.path.isdir(event.src_path):
+            file_type = 'dir'
+        else:
+            file_type = 'file'
         data = {
-            'filepath': event.src_path
+            'filepath': event.src_path,
+            'type': file_type
         }
         bmsg = BroadcastMessage(key=key, data=data)
         BroadcastManager.broadcast(bmsg)
@@ -35,9 +46,14 @@ class FilesystemEventHandler(watchdog.events.FileSystemEventHandler):
         Event Handler when a file is moved
         """
         key = 'filetree:moved_file'
+        if os.path.isdir(event.src_path):
+            file_type = 'dir'
+        else:
+            file_type = 'file'        
         data = {
             'src_filepath': event.src_path,
-            'dest_filepath': event.dest_path
+            'dest_filepath': event.dest_path,
+            'type': file_type
         }
         bmsg = BroadcastMessage(key=key, data=data)
         BroadcastManager.broadcast(bmsg)

--- a/sandstone/lib/tests/python/test_filewatcher.py
+++ b/sandstone/lib/tests/python/test_filewatcher.py
@@ -51,7 +51,8 @@ class FilewatcherTestCase(unittest.TestCase):
 
         key = 'filetree:created_file'
         data = {
-            'filepath': filepath
+            'filepath': filepath,
+            'type': 'file'
         }
         self.assertTrue(mock_broadcast.called)
         broadcast_call_msg = mock_broadcast.call_args[0][0]
@@ -72,7 +73,8 @@ class FilewatcherTestCase(unittest.TestCase):
 
         key = 'filetree:deleted_file'
         data = {
-            'filepath': filepath
+            'filepath': filepath,
+            'type': 'file'
         }
         self.assertTrue(mock_broadcast.called)
         broadcast_call_msg = mock_broadcast.call_args[0][0]
@@ -95,7 +97,8 @@ class FilewatcherTestCase(unittest.TestCase):
         key = 'filetree:moved_file'
         data = {
             'src_filepath': filepath,
-            'dest_filepath': new_path
+            'dest_filepath': new_path,
+            'type': 'file'
         }
         self.assertTrue(mock_broadcast.called)
         broadcast_call_msg = mock_broadcast.call_args[0][0]


### PR DESCRIPTION
WIP PR to rewrite the Filetree, to make it stable:

@zebulasampedro I have rewritten the methods to add a node, rewrite a node, but haven't yet stripped out everything that was there. Could you, in principal have a look at `getParentNode` function, as that is the most critical function? I have added some tests for it, and plan to add more. At this point, node expansion works in the Editor, but is broken in Filebrowser, as that requires a change in the Backend. I have at this point made minimal changes to the backend.
