### PR TITLE
Updates to FileOject permissions regex

### DIFF
--- a/sandstone/lib/filesystem/schemas.py
+++ b/sandstone/lib/filesystem/schemas.py
@@ -132,7 +132,7 @@ class FileObject(BaseObject):
         },
         'permissions': {
             'type': 'string',
-            'regex': '^([r-][w-][xts-]){3}$'
+            'regex': '^([r-][w-][xtTsS-]){3}\+?$'
         },
         'size': {
             'type': 'string',


### PR DESCRIPTION
Optional '+' at end allows for files with POSIX ACLs
'S' and 'T' are possibilities - suid & sticky bits without execute
permission
See
https://www.ibm.com/developerworks/community/blogs/brian/entry/every_possible_unix_linux_file_permission_listed_and_explained_all_4_096_of_them