### PR TITLE
Login handler is now configurable. Closes SandstoneHPC/sandstonehpc-project#38

### DIFF
--- a/sandstone/global_settings.py
+++ b/sandstone/global_settings.py
@@ -17,6 +17,10 @@ USE_SSL = False
 # this instance of Sandstone. Example: "/sandstone/user"
 URL_PREFIX = ''
 
+# Handler used to authenticate a session. The default
+# is sandstone.lib.handlers.pam_auth.PAMLoginHandler
+LOGIN_HANDLER = 'sandstone.lib.handlers.pam_auth.PAMLoginHandler'
+
 DEBUG = True
 
 COOKIE_SECRET = 'YouShouldProbablyChangeThisValueForYourProject'

--- a/sandstone/urls.py
+++ b/sandstone/urls.py
@@ -1,4 +1,3 @@
-from sandstone.lib.handlers.pam_auth import PAMLoginHandler
 from sandstone.lib.handlers.logout import LogoutHandler
 from sandstone.lib.handlers.main import MainHandler
 from sandstone.lib.handlers.state import StateHandler
@@ -12,7 +11,6 @@ import sandstone.lib.filesystem.urls as fs_api
 
 APP_SCHEMA = get_installed_app_urls()
 URL_SCHEMA = [
-            (r"/auth/login", PAMLoginHandler),
             (r"/auth/logout", LogoutHandler),
             (r"/", MainHandler),
             (r"/a/deps", DependencyHandler),


### PR DESCRIPTION
Login handlers can now be configured in settings as follows:
```python
LOGIN_HANDLER='some.module.Handler
```
Sandstone will now link `/auth/login` to the Handler specified, and rely on that handler for authentication.