### PR TITLE
Exposed shell cmd and extra env as settings. Closes SandstoneHPC/sandstonehpc-project#44.

### DIFF
--- a/sandstone/apps/webterminal/settings.py
+++ b/sandstone/apps/webterminal/settings.py
@@ -12,3 +12,10 @@ APP_SPECIFICATION = {
         'terminal.js',
     ),
 }
+
+# The command list that will be executed when a web terminal starts
+WEB_TERMINAL_SHELL_CMD = ['bash']
+# Environment variables added to web terminal sessions
+WEB_TERMINAL_EXTRA_ENV = {
+    'TEST_VAR': 'hi!'
+}

--- a/sandstone/apps/webterminal/urls.py
+++ b/sandstone/apps/webterminal/urls.py
@@ -1,9 +1,15 @@
-from terminado import UniqueTermManager
+import terminado
 from sandstone.apps.webterminal.handlers import AuthTermSocket
+from sandstone import settings
 
 
+shell_command = settings.WEB_TERMINAL_SHELL_CMD
+extra_env = settings.WEB_TERMINAL_EXTRA_ENV
 
-term_manager = UniqueTermManager(max_terminals=3,shell_command=['bash'])
+term_manager = terminado.UniqueTermManager(
+    max_terminals=3,
+    shell_command=shell_command,
+    extra_env=extra_env)
 
 URL_SCHEMA = [
             (r"/terminal/a/term", AuthTermSocket,


### PR DESCRIPTION
The command list and extra environment variables that Terminado uses to start a new terminal process have been exposed to the user as settings. This allows terminal behavior to be defined on a per-site or per-user basis.