### PR TITLE
fix issue #57

### DIFF
--- a/sandstone/apps/filebrowser/static/fb-filedetails/fb-filedetails.directive.js
+++ b/sandstone/apps/filebrowser/static/fb-filedetails/fb-filedetails.directive.js
@@ -204,7 +204,7 @@ angular.module('sandstone.filebrowser')
           FilesystemService
             .delete(self.selection.selectedFile.filepath)
             .then(function() {
-              FilebrowserService.setSelectedFile(file);
+              FilebrowserService.setSelectedFile();
             },
             function(data) {
               AlertService.addAlert({

--- a/sandstone/apps/filebrowser/static/fb-filedetails/fb-filedetails.directive.js
+++ b/sandstone/apps/filebrowser/static/fb-filedetails/fb-filedetails.directive.js
@@ -204,7 +204,7 @@ angular.module('sandstone.filebrowser')
           FilesystemService
             .delete(self.selection.selectedFile.filepath)
             .then(function() {
-              FilebrowserService.setSelectedFile();
+              FilebrowserService.setSelectedFile(file);
             },
             function(data) {
               AlertService.addAlert({

--- a/sandstone/apps/filebrowser/static/filebrowser.service.js
+++ b/sandstone/apps/filebrowser/static/filebrowser.service.js
@@ -85,7 +85,6 @@ angular.module('sandstone.filebrowser')
     var filepath = FilesystemService.normalize(data.filepath);
     var dirpath = FilesystemService.normalize(data.dirpath);
     var cwdPath = FilesystemService.normalize(selectionInfo.cwd.filepath);
-    var selPath = FilesystemService.normalize(selectionInfo.selectedFile.filepath);
 
     if(data.is_directory && (filepath === cwdPath)) {
       // CWD deleted, change cwd to selected volume
@@ -94,10 +93,6 @@ angular.module('sandstone.filebrowser')
       if(dirpath === cwdPath) {
         // Contents of CWD have changed, update them
         self.setCwd(cwdPath);
-      }
-      if(filepath === selPath) {
-        // Currently selected file deleted, deselect
-        self.setSelectedFile();
       }
     }
   });


### PR DESCRIPTION
https://github.com/SandstoneHPC/sandstonehpc-project/issues/57

@zebulasampedro a look?

The line I changed earlier was deselecting the file. However, even in the `filebrowser.service.js` method, we are deselecting the file. So the deselection is redundant. In this PR, I removed the deselection in the `filebrowser.service.js`