### PR TITLE
Issues/98

### DIFF
--- a/sandstone/apps/codeeditor/static/tabs.controller.js
+++ b/sandstone/apps/codeeditor/static/tabs.controller.js
@@ -10,7 +10,7 @@ angular.module('sandstone.editor')
       function() {
         var currentDoc = EditorService.getCurrentDoc();
         var doc = EditorService.getOpenDocs(currentDoc);
-        if (doc.changedOnDisk) {
+        if (doc.changedOnDisk && !doc.suppressChangeNotification) {
           return currentDoc;
         }
       },
@@ -167,21 +167,21 @@ angular.module('sandstone.editor')
       EditorService.openSearchBox();
     };
 
-    $document.on('keydown', function(e) {
-      if(e.ctrlKey && (e.which == 83)) {
-        var currentTab = EditorService.getCurrentDoc();
-        var tab = {
-          filepath: currentTab
-        };
-        if(e.shiftKey) {
-          self.saveDocumentAs(tab)
-        } else {
-          self.saveDocument(tab);
-        }
-        event.preventDefault();
-        return false;
-      }
-    });
+    // $document.on('keydown', function(e) {
+    //   if(e.ctrlKey && (e.which == 83)) {
+    //     var currentTab = EditorService.getCurrentDoc();
+    //     var tab = {
+    //       filepath: currentTab
+    //     };
+    //     if(e.shiftKey) {
+    //       self.saveDocumentAs(tab)
+    //     } else {
+    //       self.saveDocument(tab);
+    //     }
+    //     event.preventDefault();
+    //     return false;
+    //   }
+    // });
 
   }])
 .controller('SaveAsModalCtrl', function ($scope, $uibModalInstance, $http, file, FilesystemService) {

--- a/sandstone/lib/filesystem/filewatcher.py
+++ b/sandstone/lib/filesystem/filewatcher.py
@@ -81,25 +81,27 @@ class Filewatcher(object):
 
     @classmethod
     def add_directory_to_watch(cls, directory):
-        if directory not in cls._watches:
+        normalized_path = os.path.abspath(directory)
+        if normalized_path not in cls._watches:
             # Add the watcher
-            watch = cls._observer.schedule(cls._event_handler, directory, recursive=False)
+            watch = cls._observer.schedule(cls._event_handler, normalized_path, recursive=False)
             count = 1
             # add client count and observer to list of observers
-            cls._watches[directory] = (count,watch)
+            cls._watches[normalized_path] = (count,watch)
         else:
-            count, watch = cls._watches[directory]
+            count, watch = cls._watches[normalized_path]
             count += 1
-            cls._watches[directory] = (count,watch)
+            cls._watches[normalized_path] = (count,watch)
 
     @classmethod
     def remove_directory_to_watch(cls, directory):
-        if directory in cls._watches:
+        normalized_path = os.path.abspath(directory)
+        if normalized_path in cls._watches:
             # get the watch from the _watches dict and remove it
-            count, watch = cls._watches[directory]
+            count, watch = cls._watches[normalized_path]
             count -= 1
             if count < 1:
                 cls._observer.unschedule(watch)
-                del cls._watches[directory]
+                del cls._watches[normalized_path]
             else:
-                cls._watches[directory] = (count,watch)
+                cls._watches[normalized_path] = (count,watch)


### PR DESCRIPTION
Hotfix for SandstoneHPC/sandstonehpc-project#98.

* Disable the keyboard shortcut for document saves in the editor. This functionality will be returned, but priority right now is on a stable master release.
* Normalize watcher paths prior to lookup
* Fixed incorrect conditional